### PR TITLE
Allow reassignment of exec.Cmd Stdout and Stderr

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,17 @@ The choice of which browser is started is entirely client dependant.
 
 
 
+## Variables
+``` go
+var Stderr io.Writer = os.Stderr
+```
+Stderr is the io.Writer to which executed commands write standard error.
+
+``` go
+var Stdout io.Writer = os.Stdout
+```
+Stdout is the io.Writer to which executed commands write standard output.
+
 
 ## func OpenFile
 ``` go

--- a/browser.go
+++ b/browser.go
@@ -12,6 +12,12 @@ import (
 	"path/filepath"
 )
 
+// Stdout is the io.Writer to which executed commands write standard output.
+var Stdout io.Writer = os.Stdout
+
+// Stderr is the io.Writer to which executed commands write standard error.
+var Stderr io.Writer = os.Stderr
+
 // OpenFile opens new browser window for the file path.
 func OpenFile(path string) error {
 	path, err := filepath.Abs(path)
@@ -50,7 +56,7 @@ func OpenURL(url string) error {
 
 func runCmd(prog string, args ...string) error {
 	cmd := exec.Command(prog, args...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	cmd.Stdout = Stdout
+	cmd.Stderr = Stderr
 	return cmd.Run()
 }


### PR DESCRIPTION
Sometimes the command that's executed can print unnecessary things to standard output and standard error. For example, on my system `xdg-open` first prints a segfault, then says no method is available for opening the file, but the file is opened in my browser anyway.

So it'd be nice to be able to reassign the executed command's `Stdout` and `Stderr` to something other than the defaults.