### PR TITLE
Don't use `sensible-browser` directly (linux)

### DIFF
--- a/browser_linux.go
+++ b/browser_linux.go
@@ -1,10 +1,5 @@
 package browser
 
 func openBrowser(url string) error {
-	// try sensible-browser first
-	if err := runCmd("sensible-browser", url); err == nil {
-		return nil
-	}
-	// sensible-browser not availble, try xdg-open
 	return runCmd("xdg-open", url)
 }


### PR DESCRIPTION
`sensible-browser` blocks the current process and doesn't open the
expected browser (using system vs user default).

`xdg-open` is non-blocking, uses the user default browser, and falls
back to using `sensible-browser`.

See https://github.com/flynn/flynn/issues/2125#issuecomment-156953583