### PR TITLE
Fix Windows code to allow multiple GET parameters

### DIFF
--- a/browser_windows.go
+++ b/browser_windows.go
@@ -1,5 +1,10 @@
 package browser
 
+import (
+	"strings"
+)
+
 func openBrowser(url string) error {
-	return runCmd("cmd", "/c", "start", url)
+	r := strings.NewReplacer("&", "^&")
+	return runCmd("cmd", "/c", "start", r.Replace(url))
 }


### PR DESCRIPTION
Command Prompt needs to escape "&" to accept multiple GET parameters.