### PR TITLE
Support OpenBSD

### DIFF
--- a/browser_openbsd.go
+++ b/browser_openbsd.go
@@ -1,0 +1,16 @@
+package browser
+
+import (
+	"errors"
+	"os/exec"
+)
+
+var errNoXdgOpen = errors.New("xdg-open: command not found - install xdg-utils from ports(8)")
+
+func openBrowser(url string) error {
+	err := runCmd("xdg-open", url)
+	if e, ok := err.(*exec.Error); ok && e.Err == exec.ErrNotFound {
+		return errNoXdgOpen
+	}
+	return err
+}

--- a/browser_unsupported.go
+++ b/browser_unsupported.go
@@ -1,4 +1,4 @@
-// +build !linux,!windows,!darwin
+// +build !linux,!windows,!darwin,!openbsd
 
 package browser
 


### PR DESCRIPTION
Xdg is in the official ports tree and can be installed with `pkg_add xdg-utils`.

http://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/devel/xdg-utils/