### PR TITLE
Hide console in windows when launching process

### DIFF
--- a/browser.go
+++ b/browser.go
@@ -58,5 +58,6 @@ func runCmd(prog string, args ...string) error {
 	cmd := exec.Command(prog, args...)
 	cmd.Stdout = Stdout
 	cmd.Stderr = Stderr
+	setFlags(cmd)
 	return cmd.Run()
 }

--- a/browser_darwin.go
+++ b/browser_darwin.go
@@ -1,5 +1,9 @@
 package browser
 
+import "os/exec"
+
 func openBrowser(url string) error {
 	return runCmd("open", url)
 }
+
+func setFlags(cmd *exec.Cmd) {}

--- a/browser_linux.go
+++ b/browser_linux.go
@@ -1,5 +1,9 @@
 package browser
 
+import "os/exec"
+
 func openBrowser(url string) error {
 	return runCmd("xdg-open", url)
 }
+
+func setFlags(cmd *exec.Cmd) {}

--- a/browser_openbsd.go
+++ b/browser_openbsd.go
@@ -12,3 +12,5 @@ func openBrowser(url string) error {
 	}
 	return err
 }
+
+func setFlags(cmd *exec.Cmd) {}

--- a/browser_unsupported.go
+++ b/browser_unsupported.go
@@ -4,9 +4,12 @@ package browser
 
 import (
 	"fmt"
+	"os/exec"
 	"runtime"
 )
 
 func openBrowser(url string) error {
 	return fmt.Errorf("openBrowser: unsupported operating system: %v", runtime.GOOS)
 }
+
+func setFlags(cmd *exec.Cmd) {}

--- a/browser_windows.go
+++ b/browser_windows.go
@@ -1,10 +1,16 @@
 package browser
 
 import (
+	"os/exec"
 	"strings"
+	"syscall"
 )
 
 func openBrowser(url string) error {
 	r := strings.NewReplacer("&", "^&")
 	return runCmd("cmd", "/c", "start", r.Replace(url))
+}
+
+func setFlags(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
 }


### PR DESCRIPTION
This prevents the console window from appearing when the process is launched within Windows. For other architectures it is a noop.

Fixes #12 .