### PR TITLE
Add support for the BROWSER environment variable

### DIFF
--- a/browser.go
+++ b/browser.go
@@ -55,9 +55,24 @@ func OpenURL(url string) error {
 }
 
 func runCmd(prog string, args ...string) error {
-	cmd := exec.Command(prog, args...)
+	var cmd *exec.Cmd
+
+	browser := envBrowserCmd()
+	if browser != "" {
+		sh, flag := shell()
+		url := args[len(args)-1]
+		browserCmd := fmtBrowserCmd(browser, url)
+		cmd = exec.Command(sh, flag, browserCmd)
+	} else {
+		cmd = exec.Command(prog, args...)
+	}
+
 	cmd.Stdout = Stdout
 	cmd.Stderr = Stderr
 	setFlags(cmd)
 	return cmd.Run()
+}
+
+func envBrowserCmd() string {
+	return os.Getenv("BROWSER")
 }

--- a/browser_unix.go
+++ b/browser_unix.go
@@ -1,0 +1,22 @@
+// +build !windows
+
+package browser
+
+import (
+	"fmt"
+	"os"
+)
+
+func shell() (shell, flag string) {
+	shell = os.Getenv("SHELL")
+
+	if shell == "" {
+		shell = "/bin/sh"
+	}
+
+	return shell, "-c"
+}
+
+func fmtBrowserCmd(browser, url string) string {
+	return fmt.Sprintf("%s '%s'", browser, url)
+}

--- a/browser_windows.go
+++ b/browser_windows.go
@@ -1,6 +1,7 @@
 package browser
 
 import (
+	"fmt"
 	"os/exec"
 	"strings"
 	"syscall"
@@ -13,4 +14,12 @@ func openBrowser(url string) error {
 
 func setFlags(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+}
+
+func shell() (shell, flag string) {
+	return "cmd", "/c"
+}
+
+func fmtBrowserCmd(browser, url string) string {
+	return fmt.Sprintf("%s %s", browser, url)
 }


### PR DESCRIPTION
Allow user-defined URL-opening commands via the BROWSER environment
variable. This enables using a non-default browser, or changing the
browser for a single command.

For example, on Mac:

    $ export BROWSER='open -a Firefox'

Windows:

    > setx BROWSER "start iexplore"

In UNIX environments, the command is run through `$SHELL -c`, or
`/bin/sh` if `$SHELL` is not set. On Windows, it uses `cmd /c`.

Ensure that URLs are properly quoted between UNIX and Windows
environments in `fmtBrowserCmd()`.

Tested manually on Mac OS X and Windows 10.