### PR TITLE
Fix xdg-open behavior

### DIFF
--- a/browser_linux.go
+++ b/browser_linux.go
@@ -26,7 +26,7 @@ func openBrowser(url string) error {
 		return err
 	}
 	if !appearsSuccessful(cmd, 3*time.Second) {
-		return err.New("Unable to successfully run xdg-open")
+		return error.New("Unable to successfully run xdg-open")
 	}
 	return nil
 }

--- a/browser_linux.go
+++ b/browser_linux.go
@@ -1,9 +1,34 @@
 package browser
 
-import "os/exec"
+import (
+	"os/exec"
+	"time"
+)
+
+func appearsSuccessful(cmd *exec.Cmd, timeout time.Duration) bool {
+	errc := make(chan error, 1)
+	go func() {
+		errc <- cmd.Wait()
+	}()
+
+	select {
+	case <-time.After(timeout):
+		return true
+	case err := <-errc:
+		return err == nil
+	}
+}
 
 func openBrowser(url string) error {
-	return runCmd("xdg-open", url)
+	cmd := exec.Command("xdg-open", url)
+	err := cmd.Start()
+	if err != nil {
+		return err
+	}
+	if !appearsSuccessful(cmd, 3*time.Second) {
+		return err.New("Unable to successfully run xdg-open")
+	}
+	return nil
 }
 
 func setFlags(cmd *exec.Cmd) {}

--- a/browser_linux.go
+++ b/browser_linux.go
@@ -1,6 +1,7 @@
 package browser
 
 import (
+	"errors"
 	"os/exec"
 	"time"
 )
@@ -26,7 +27,7 @@ func openBrowser(url string) error {
 		return err
 	}
 	if !appearsSuccessful(cmd, 3*time.Second) {
-		return error.New("Unable to successfully run xdg-open")
+		return errors.New("Unable to successfully run xdg-open")
 	}
 	return nil
 }


### PR DESCRIPTION
xdg-open behavior isn't well defined. `pkg/browser` expects it to spawn one in the background and return immediately.

Similar code within golang doesn't assume this xdg-open behavior:

https://github.com/golang/go/blob/master/src/cmd/internal/browser/browser.go#L41

This patch uses similar code.