### PR TITLE
Add support for x-www-browser and www-browser in linux

### DIFF
--- a/browser_linux.go
+++ b/browser_linux.go
@@ -1,9 +1,23 @@
 package browser
 
-import "os/exec"
+import (
+	"os/exec"
+	"strings"
+)
 
 func openBrowser(url string) error {
-	return runCmd("xdg-open", url)
+	providers := []string{"xdg-open", "x-www-browser", "www-browser"}
+
+	// There are multiple possible providers to open a browser on linux
+	// One of them is xdg-open, another is x-www-browser, then there's www-browser, etc.
+	// Look for one that exists and run it
+	for _, provider := range providers {
+		if _, err := exec.LookPath(provider); err == nil {
+			return runCmd(provider, url)
+		}
+	}
+
+	return &exec.Error{Name: strings.Join(providers, ","), Err: exec.ErrNotFound}
 }
 
 func setFlags(cmd *exec.Cmd) {}


### PR DESCRIPTION
This implements support for various setups on linux that do not have xdg-open present but do have x-www-browser or www-browser. Debian and Ubuntu running on wsl fall in this category, but some pure linux setups do as well, making this a lovely general fix I think :)