### PR TITLE
Fix running project on Windows

### DIFF
--- a/browser.go
+++ b/browser.go
@@ -58,6 +58,5 @@ func runCmd(prog string, args ...string) error {
 	cmd := exec.Command(prog, args...)
 	cmd.Stdout = Stdout
 	cmd.Stderr = Stderr
-	setFlags(cmd)
 	return cmd.Run()
 }

--- a/browser_darwin.go
+++ b/browser_darwin.go
@@ -5,5 +5,3 @@ import "os/exec"
 func openBrowser(url string) error {
 	return runCmd("open", url)
 }
-
-func setFlags(cmd *exec.Cmd) {}

--- a/browser_freebsd.go
+++ b/browser_freebsd.go
@@ -12,5 +12,3 @@ func openBrowser(url string) error {
 	}
 	return err
 }
-
-func setFlags(cmd *exec.Cmd) {}

--- a/browser_linux.go
+++ b/browser_linux.go
@@ -19,5 +19,3 @@ func openBrowser(url string) error {
 
 	return &exec.Error{Name: strings.Join(providers, ","), Err: exec.ErrNotFound}
 }
-
-func setFlags(cmd *exec.Cmd) {}

--- a/browser_openbsd.go
+++ b/browser_openbsd.go
@@ -12,5 +12,3 @@ func openBrowser(url string) error {
 	}
 	return err
 }
-
-func setFlags(cmd *exec.Cmd) {}

--- a/browser_unsupported.go
+++ b/browser_unsupported.go
@@ -11,5 +11,3 @@ import (
 func openBrowser(url string) error {
 	return fmt.Errorf("openBrowser: unsupported operating system: %v", runtime.GOOS)
 }
-
-func setFlags(cmd *exec.Cmd) {}

--- a/browser_windows.go
+++ b/browser_windows.go
@@ -1,12 +1,12 @@
 //go:generate mkwinsyscall -output zbrowser_windows.go browser_windows.go
-//sys ShellExecute(hwnd int, verb string, file string, args string, cwd string, showCmd int) (err error) = shell32.ShellExecuteW
+//sys shellExecute(hwnd int, verb string, file string, args string, cwd string, showCmd int) (err error) = shell32.ShellExecuteW
 package browser
 
 import "os/exec"
-const SW_SHOWNORMAL = 1
+const sW_SHOWNORMAL = 1
 
 func openBrowser(url string) error {
-   return ShellExecute(0, "", url, "", "", SW_SHOWNORMAL)
+   return shellExecute(0, "", url, "", "", sW_SHOWNORMAL)
 }
 
 func setFlags(cmd *exec.Cmd) {

--- a/browser_windows.go
+++ b/browser_windows.go
@@ -3,11 +3,9 @@
 package browser
 
 import "os/exec"
+
 const sW_SHOWNORMAL = 1
 
 func openBrowser(url string) error {
-   return shellExecute(0, "", url, "", "", sW_SHOWNORMAL)
-}
-
-func setFlags(cmd *exec.Cmd) {
+	return shellExecute(0, "", url, "", "", sW_SHOWNORMAL)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/pkg/browser
 
 go 1.14
+
+require golang.org/x/sys v0.0.0-20210319071255-635bc2c9138d // indirect

--- a/zbrowser_windows.go
+++ b/zbrowser_windows.go
@@ -43,7 +43,7 @@ var (
 	procShellExecuteW = modshell32.NewProc("ShellExecuteW")
 )
 
-func ShellExecute(hwnd int, verb string, file string, args string, cwd string, showCmd int) (err error) {
+func shellExecute(hwnd int, verb string, file string, args string, cwd string, showCmd int) (err error) {
 	var _p0 *uint16
 	_p0, err = syscall.UTF16PtrFromString(verb)
 	if err != nil {
@@ -64,10 +64,10 @@ func ShellExecute(hwnd int, verb string, file string, args string, cwd string, s
 	if err != nil {
 		return
 	}
-	return _ShellExecute(hwnd, _p0, _p1, _p2, _p3, showCmd)
+	return _shellExecute(hwnd, _p0, _p1, _p2, _p3, showCmd)
 }
 
-func _ShellExecute(hwnd int, verb *uint16, file *uint16, args *uint16, cwd *uint16, showCmd int) (err error) {
+func _shellExecute(hwnd int, verb *uint16, file *uint16, args *uint16, cwd *uint16, showCmd int) (err error) {
 	r1, _, e1 := syscall.Syscall6(procShellExecuteW.Addr(), 6, uintptr(hwnd), uintptr(unsafe.Pointer(verb)), uintptr(unsafe.Pointer(file)), uintptr(unsafe.Pointer(args)), uintptr(unsafe.Pointer(cwd)), uintptr(showCmd))
 	if r1 == 0 {
 		err = errnoErr(e1)


### PR DESCRIPTION
`go run ./examples/Open` in this project resulted in an error on Windows because the runtime now references a `golang.org/x/sys` package that wasn't listed in `go.mod`.

Also un-exports Windows-specific identifiers.

Also removes the `setFlags` func which is now a no-op across all platforms.

Ref. #27