### PR TITLE
Remove os/exec import since not being used

### DIFF
--- a/browser_darwin.go
+++ b/browser_darwin.go
@@ -1,7 +1,5 @@
 package browser
 
-import "os/exec"
-
 func openBrowser(url string) error {
 	return runCmd("open", url)
 }


### PR DESCRIPTION
Was facing the following error :
```
go/pkg/mod/github.com/pkg/browser@v0.0.0-20210605161147-93ea1f481b79/browser_darwin.go:3:8: imported and not used: "os/exec"
```

I guess this will fix it.