### PR TITLE
Create temporary file with .html extension in OpenReader

### DIFF
--- a/browser.go
+++ b/browser.go
@@ -30,7 +30,7 @@ func OpenFile(path string) error {
 // OpenReader consumes the contents of r and presents the
 // results in a new browser window.
 func OpenReader(r io.Reader) error {
-	f, err := ioutil.TempFile("", "browser")
+	f, err := ioutil.TempFile("", "browser.*.html")
 	if err != nil {
 		return fmt.Errorf("browser: could not create temporary file: %v", err)
 	}
@@ -41,12 +41,7 @@ func OpenReader(r io.Reader) error {
 	if err := f.Close(); err != nil {
 		return fmt.Errorf("browser: caching temporary file failed: %v", err)
 	}
-	oldname := f.Name()
-	newname := oldname + ".html"
-	if err := os.Rename(oldname, newname); err != nil {
-		return fmt.Errorf("browser: renaming temporary file failed: %v", err)
-	}
-	return OpenFile(newname)
+	return OpenFile(f.Name())
 }
 
 // OpenURL opens a new browser window pointing to url.


### PR DESCRIPTION
Rather than creating a temporary file and then renaming it to have a
.html extension, create the temporary file with the extension directly.