### PR TITLE
Add `go:build` line

### DIFF
--- a/browser_unsupported.go
+++ b/browser_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux && !windows && !darwin && !openbsd && !freebsd
 // +build !linux,!windows,!darwin,!openbsd,!freebsd
 
 package browser


### PR DESCRIPTION
This was added by Go 1.17. Go official recommends to use both new and old forms.
Ref: https://golang.org/doc/go1.17#build-lines