### PR TITLE
remove unused import in unsupported

### DIFF
--- a/browser_unsupported.go
+++ b/browser_unsupported.go
@@ -4,7 +4,6 @@ package browser
 
 import (
 	"fmt"
-	"os/exec"
 	"runtime"
 )
 


### PR DESCRIPTION
os/exec is unused cause build error with browser_unsupported

../../pkg/mod/github.com/pkg/browser@v0.0.0-20210706143420-7d21f8c997e2/browser_unsupported.go:7:2: imported and not used: "os/exec"