### PR TITLE
Add support for NetBSD.

### DIFF
--- a/browser_netbsd.go
+++ b/browser_netbsd.go
@@ -1,0 +1,14 @@
+package browser
+
+import (
+	"errors"
+	"os/exec"
+)
+
+func openBrowser(url string) error {
+	err := runCmd("xdg-open", url)
+	if e, ok := err.(*exec.Error); ok && e.Err == exec.ErrNotFound {
+		return errors.New("xdg-open: command not found - install xdg-utils from pkgsrc(7)")
+	}
+	return err
+}

--- a/browser_unsupported.go
+++ b/browser_unsupported.go
@@ -1,4 +1,4 @@
-// +build !linux,!windows,!darwin,!openbsd,!freebsd
+// +build !linux,!windows,!darwin,!openbsd,!freebsd,!netbsd
 
 package browser
 


### PR DESCRIPTION
This patch adds support NetBSD and was tested in NetBSD 9.2.

```shell
$ ./main
http://www.google.com
/usr/pkg/bin/xdg-open: line 871: www-browser: command not found
/usr/pkg/bin/xdg-open: line 871: links2: command not found
/usr/pkg/bin/xdg-open: line 871: elinks: command not found
/usr/pkg/bin/xdg-open: line 871: links: command not found
/usr/pkg/bin/xdg-open: line 871: lynx: command not found
/usr/pkg/bin/xdg-open: line 871: w3m: command not found
xdg-open: no method available for opening 'file:///tmp/browser.1539593927.html'
2021/09/09 19:05:00 exit status 3
$ uname -a
NetBSD netbsd-build 9.2 NetBSD 9.2 (GENERIC) #0: Wed May 12 13:15:55 UTC 2021  mkrepro@mkrepro.NetBSD.org:/usr/src/sys/arch/amd64/compile/GENERIC amd64
```

And it opens one of them if they are present.